### PR TITLE
Upgrade to 2.6.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,14 @@
 FROM openjdk:8-alpine
-LABEL VERSION 0.2
+LABEL VERSION 0.3
 LABEL MAINTAINER Anam Ahmed (anam.ahmed.a@gmail.com)
 
-ENV APKTOOL_VERSION=2.4.0
+ENV APKTOOL_VERSION=2.6.0
 RUN apk add --no-cache curl bash
 
 WORKDIR /usr/local/bin
 
 RUN curl -sLO https://raw.githubusercontent.com/iBotPeaches/Apktool/master/scripts/linux/apktool && chmod +x apktool
-RUN curl -sL -o apktool.jar https://bitbucket.org/iBotPeaches/apktool/downloads/${APKTOOL_VERSION} && chmod +x apktool.jar
+RUN curl -sL -o apktool.jar https://bitbucket.org/iBotPeaches/apktool/downloads/apktool_${APKTOOL_VERSION}.jar && chmod +x apktool.jar
 
 VOLUME ["/app"]
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 ## Docker Image for apktool
 
 
-Based on `OpenJDK 8` and `Apktool 2.4.0`, I have plans to keep this updated (you can contribute too)
+Based on `OpenJDK 8` and `Apktool 2.8.0`.
 
 ### System Requirements:
 
 * [Docker](https://www.docker.com/get-started) 18.06.1+
 
+### Building the Container
+This assumes that you've cloned the repository locally:
+
+   docker build . --tag docker-apktool:latest
+
 ### How to use: 
 
-for `99.99%` of cases, you probably want to run the command once, and then remove the container.
+For `99.99%` of cases, you probably want to run the command once, and then remove the container.
 
 To run it once use the following command (will take longer for the first time):
 
-    docker run --rm -v `pwd`:/app theanam/apktool d apk_file.apk
+    docker run --rm -v `pwd`:/app docker-apktool d apk_file.apk
 
 this should decompile the apk file `apk_file.apk`
 
@@ -21,7 +26,7 @@ this should decompile the apk file `apk_file.apk`
 
 You might convert the above command to an alias. Open your `.bashrc` or `.zshrc` or any other shell configuration file, add the following at the very end:
 
-    alias apktool="docker run --rm -v `pwd`:/app theanam/apktool"
+    alias apktool="docker run --rm -v `pwd`:/app docker-apktool"
 
 once you close and open a new terminal window once after that, you can use the tool from command line in a cleaner way as the command (apktool) will be available:
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Docker Image for apktool
 
 
-Based on `OpenJDK 8` and `Apktool 2.8.0`.
+Based on `OpenJDK 8` and `Apktool 2.6.0`.
 
 ### System Requirements:
 


### PR DESCRIPTION
Upgraded the Container to utilize `apktool` 2.6.0 the following changes had to be made:

* The URL from which to download `apktool` has changed slightly
* Added information to the `README.md` to indicate how to build this container locally, changing the name of the tag.
* Bumped the Version

I tested this on my Raspberry Pi 4 with great success.

Thank you for this container.